### PR TITLE
mkfn: print usage to stderr and return 1 on bad options

### DIFF
--- a/mkfn.c
+++ b/mkfn.c
@@ -232,8 +232,8 @@ int main(int argc, char *argv[])
 			mkfn_warn = 1;
 			break;
 		default:
-			printf("%s", usage);
-			return 0;
+			fprintf(stderr, "%s", usage);
+			return 1;
 		}
 	}
 	trfn_init();


### PR DESCRIPTION
so that if an incorrect option is given in a pipeline, the error message can be seen.